### PR TITLE
chore: promote aspjxproject to version 0.0.1

### DIFF
--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-cfrrm-rb.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-cfrrm-rb.yaml
@@ -2,7 +2,7 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-ulwcp
+  name: jx-verify-gc-jobs-cfrrm
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
   namespace: jx-production

--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-t8zyc-job.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-t8zyc-job.yaml
@@ -2,12 +2,12 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-sb3zu
+  name: jx-verify-gc-jobs-t8zyc
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-89hpb
+    app: jx-verify-gc-jobs-q25ms
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-production

--- a/config-root/namespaces/jx-staging/aspjxproject/aspjxproject-aspjxproject-deploy.yaml
+++ b/config-root/namespaces/jx-staging/aspjxproject/aspjxproject-aspjxproject-deploy.yaml
@@ -1,0 +1,60 @@
+# Source: aspjxproject/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: aspjxproject-aspjxproject
+  labels:
+    draft: draft-app
+    chart: "aspjxproject-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'aspjxproject'
+    wave.pusher.com/update-on-config-change: 'true'
+  namespace: jx-staging
+spec:
+  selector:
+    matchLabels:
+      app: aspjxproject-aspjxproject
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: aspjxproject-aspjxproject
+    spec:
+      serviceAccountName: aspjxproject-aspjxproject
+      containers:
+      - name: aspjxproject
+        image: "gcr.io/jenkinsxdemo-371022/aspjxproject:0.0.1"
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: VERSION
+          value: 0.0.1
+        envFrom: null
+        ports:
+        - name: http
+          containerPort: 80
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 80
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 80
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: 400m
+            memory: 256Mi
+          requests:
+            cpu: 200m
+            memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-staging/aspjxproject/aspjxproject-aspjxproject-sa.yaml
+++ b/config-root/namespaces/jx-staging/aspjxproject/aspjxproject-aspjxproject-sa.yaml
@@ -1,0 +1,10 @@
+# Source: aspjxproject/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aspjxproject-aspjxproject
+  annotations:
+    meta.helm.sh/release-name: 'aspjxproject'
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-staging/aspjxproject/aspjxproject-ingress.yaml
+++ b/config-root/namespaces/jx-staging/aspjxproject/aspjxproject-ingress.yaml
@@ -1,0 +1,22 @@
+# Source: aspjxproject/templates/ingress.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    meta.helm.sh/release-name: 'aspjxproject'
+  name: aspjxproject
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+  - http:
+      paths:
+      - pathType: ImplementationSpecific
+        backend:
+          service:
+            name: aspjxproject
+            port:
+              number: 80
+    host: aspjxproject-jx-staging.23.251.147.105.nip.io

--- a/config-root/namespaces/jx-staging/aspjxproject/aspjxproject-svc.yaml
+++ b/config-root/namespaces/jx-staging/aspjxproject/aspjxproject-svc.yaml
@@ -1,0 +1,20 @@
+# Source: aspjxproject/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: aspjxproject
+  labels:
+    chart: "aspjxproject-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'aspjxproject'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+    targetPort: 80
+    protocol: TCP
+    name: http
+  selector:
+    app: aspjxproject-aspjxproject

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-51f7z-job.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-51f7z-job.yaml
@@ -2,12 +2,12 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-dvppy
+  name: jx-verify-gc-jobs-51f7z
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-mr1hn
+    app: jx-verify-gc-jobs-iipls
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-mc4pu-rb.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-mc4pu-rb.yaml
@@ -2,7 +2,7 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-gsbkk
+  name: jx-verify-gc-jobs-mc4pu
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
   namespace: jx-staging

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,13 @@
 	      <td></td>
 	    </tr>
     <tr>
+	      <td>aspjxproject</td>
+	      <td title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> aspjxproject</td>
+	      <td>0.0.1</td>
+	      <td></td>
+	      <td></td>
+	    </tr>
+    <tr>
 		      <td colspan='5'><h3>jx</h3></td>
 		    </tr>
 	    <tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -34,6 +34,19 @@
     repositoryName: jxgh
     repositoryUrl: https://jenkins-x-charts.github.io/repo
     resourcePath: config-root/namespaces/jx-staging/jx-verify
+  - apiVersion: v1
+    appVersion: 0.0.1
+    description: A Helm chart for Kubernetes
+    firstDeployed: "2022-12-09T04:07:07Z"
+    icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
+    lastDeployed: "2022-12-09T04:07:07Z"
+    logsUrl: https://console.cloud.google.com/logs/viewer?authuser=1&project=jenkinsxdemo-371022&minLogLevel=0&expandAll=false&customFacets=&limitCustomFacetWidth=true&interval=PT1H&resource=k8s_container%2Fcluster_name%2Flfs268-lab%2Fnamespace_name%2Fjx-staging%2Fcontainer_name%2Faspjxproject&dateRangeUnbound=both
+    name: aspjxproject
+    releaseName: aspjxproject
+    repositoryName: dev
+    repositoryUrl: http://chartmuseum-jx.23.251.147.105.nip.io
+    resourcePath: config-root/namespaces/jx-staging/aspjxproject
+    version: 0.0.1
 - namespace: jx
   path: helmfiles/jx/helmfile.yaml
   releases:

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -6,11 +6,17 @@ environments:
 repositories:
 - name: jxgh
   url: https://jenkins-x-charts.github.io/repo
+- name: dev
+  url: http://chartmuseum-jx.23.251.147.105.nip.io
 releases:
 - chart: jxgh/jx-verify
   name: jx-verify
   namespace: jx-staging
   values:
   - jx-values.yaml
+- chart: dev/aspjxproject
+  version: 0.0.1
+  name: aspjxproject
+  namespace: jx-staging
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -18,5 +18,7 @@ releases:
   version: 0.0.1
   name: aspjxproject
   namespace: jx-staging
+  values:
+  - jx-values.yaml
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote aspjxproject to version 0.0.1

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge